### PR TITLE
Sheduler Refactor with RMI 

### DIFF
--- a/src/scheduler/Scheduler.java
+++ b/src/scheduler/Scheduler.java
@@ -177,6 +177,7 @@ public class Scheduler {
      * Starts the system
      */
     public void startSystem() {
+        //TODO: Graceful shutdown
         //ToDo: complete SchedulerV2, port changes over to scheduler class so this method can be called.
 //        currentState = SchedulerState.start(this);
 //        readBuffer();

--- a/src/scheduler/Scheduler.java
+++ b/src/scheduler/Scheduler.java
@@ -1,22 +1,55 @@
+//package scheduler;
+//
+//import org.junit.runner.Runner;
+//import util.SubSystemSharedState;
+//
+//import java.rmi.AlreadyBoundException;
+//import java.rmi.RemoteException;
+//import java.rmi.registry.LocateRegistry;
+//import java.rmi.registry.Registry;
+//
+//public class SchedulerV2 implements Runnable {
+//    private SubSystemSharedState sharedState;
+//    Registry registry;
+//
+//
+//    public SchedulerV2(SubSystemSharedState sharedState) throws RemoteException, AlreadyBoundException {
+//        this.sharedState = sharedState;
+//        registry = LocateRegistry.getRegistry();
+//        registry.bind("SharedSubSystemState", sharedState);
+//    }
+//
+//
+//    public void schedule(){
+//        // Grab the state, then make assignents.
+//
+//    }
+//    public void run () {
+//        while (true) {
+//            // do something
+//
+//        }
+//    }
+//}
+
 package scheduler;
 
-import util.ElevatorLogger;
-import util.MessageHelper;
+import scheduler.strategies.AllocationStrategy;
+import scheduler.strategies.LoadBalancedStrategy;
+import util.*;
 import util.Messages.MessageTypes;
 import util.Messages.SerializableMessage;
-import util.states.SchedulerScheduling;
+import util.Messages.Signal;
 import util.states.SchedulerState;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
+import java.net.*;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 
 /**
@@ -29,219 +62,114 @@ public class Scheduler {
     private DatagramSocket inSocket;
     private DatagramSocket outSocket;
     private SchedulerState currentState;
+    private SubSystemSharedState sharedState;
+
+    private
+    Registry registry;
 
     // Key is Message ID, Value is the message
     //Requests are taken from the shared buffer and parsed into the appropriate buffer, these are requests that have yet
     //to be serviced
-    final ConcurrentHashMap<String, SerializableMessage> elevatorRequestBuffer = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, SerializableMessage> floorRequestBuffer = new ConcurrentHashMap<>();
 
-    //Key is Elevator/floor ID, Value is the message, store for elevators ready for work
-    private final HashMap<String, SerializableMessage> idleElevators = new HashMap<>();
-
-    //Key is Elevator/floor ID, Value is the message, store for elevators currently working
-    private final HashMap<String, SerializableMessage> workingElevators = new HashMap<>();
-
-    //Key is Message ID, Value is the message, store for floor requests that are pending
-    private final HashMap<String, SerializableMessage> pendingFloorRequests = new HashMap<>();
-
-    //Key is Message ID, Value is the message, store for elevator requests that are pending
-    private HashMap<String, SerializableMessage> pendingElevatorRequests = new HashMap<>();
     private static final ElevatorLogger logger = new ElevatorLogger("Scheduler");
+
+    private HashMap<String, WorkAssignment> assignedWork;
 
     private int elevatorSubSystemPort;
     private int floorSubSystemPort;
     volatile boolean testStopBit;
+    private MessageBuffer floorMessageBuffer;
+    private AllocationStrategy allocationStrategy;
+
+    private ConcurrentLinkedDeque<WorkAssignment> pendingWorkAssignments;
 
 
     /**
      *  Creates a Scheduler
      * @param schedulerAddr The Internet address of the scheduler
      * @param schedulerPort The port that the scheduler listens to
-     * @param elevatorSubSystemPort The port that the elevator system listens to
      * @param floorSubSystemPort The port that the floor system listens to
      */
-        public Scheduler(InetAddress schedulerAddr, int schedulerPort, int elevatorSubSystemPort, int floorSubSystemPort) {
-            try {
-                this.floorSubSystemPort = floorSubSystemPort;
-                this.elevatorSubSystemPort = elevatorSubSystemPort;
-                inSocket = new DatagramSocket(schedulerPort, schedulerAddr);
-                outSocket = new DatagramSocket();
-                testStopBit = true;
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            currentState = null; // Started with startSystem()
+    public Scheduler(InetAddress schedulerAddr, int schedulerPort, int floorSubSystemPort, AllocationStrategy allocationStrategy, SubSystemSharedState sharedState) {
+        try {
+            this.floorSubSystemPort = floorSubSystemPort;
+//            this.elevatorSubSystemPort = elevatorSubSystemPort;
+            inSocket = new DatagramSocket(schedulerPort, schedulerAddr);
+            InetSocketAddress inetSocketAddress = new InetSocketAddress(schedulerAddr, schedulerPort);
+            outSocket = new DatagramSocket();
+            floorMessageBuffer = new MessageBuffer("FloorMessageBuffer", inSocket, inetSocketAddress, schedulerPort);
+            testStopBit = true;
+            this.sharedState = sharedState;
+            registry = LocateRegistry.getRegistry();
+            registry.bind("SharedSubSystemState", sharedState);
+            assignedWork = new HashMap<>();
+            this.allocationStrategy = allocationStrategy;
+            this.sharedState.setScheduler(this);
+//            floorMessageBuffer.listenAndFillBuffer();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-
-
-
-
-
-    /**
-     *
-     * @return A HashMap containing the idle elevators.
-     */
-
-    public HashMap<String, SerializableMessage> getIdleElevators() {
-        return idleElevators;
-    }
-
-    /**
-     *
-     * @return A HashMap containing the working elevators.
-     */
-    public HashMap<String, SerializableMessage> getWorkingElevators() {
-        return workingElevators;
-    }
-
-    /**
-     *
-     * @return A HashMap containing the pending floor requests.
-     */
-    public HashMap<String, SerializableMessage> getPendingFloorRequests() {
-        return pendingFloorRequests;
-    }
-
-    /**
-     *
-     * @return A HashMap containing the pending elevator requests.
-     */
-    public ConcurrentHashMap<String, SerializableMessage> getFloorRequestBuffer() {
-        return floorRequestBuffer;
+        currentState = null; // Started with startSystem()
     }
 
 
-    /**
-     * Retrieves messages from the elevatorRequestBuffer, this is called after the messages have been removed from the
-     * shared buffer. Only scheduler.Scheduler has access to this buffer.
-     * Close requests once they are fulfilled. it is called after thread woken up from wait
-     * and messages are in the buffer.
-     * No params, no return, public for testing purposes
-     */
-    public void serveElevatorReqs() throws IOException {
-        String[] keys = elevatorRequestBuffer.keySet().toArray(new String[0]);
-        for (String messageId : keys) {
-            SerializableMessage message = elevatorRequestBuffer.get(messageId);
-            logger.info("Elevator Request. SenderID: " + message.senderID() + " Signal: " + message.signal());
-            if (message.type().equals(MessageTypes.ELEVATOR)){
-                switch (message.signal()) {
-                    case IDLE:
-                        idleElevators.put(String.valueOf(message.senderID()), message);
-                        logger.info("Elevator " + message.senderID() + " is now idle");
-                        break;
-                    case WORKING:
-                        //USES Sender ID as KEY
-                        workingElevators.put(String.valueOf(message.senderID()), message);
-                        logger.info("Elevator " + message.senderID() + " is now working");
-                        break;
-                    case DONE:
-                        logger.info("Elevator " + message.senderID() + " is now done");
-                        workingElevators.remove(message.senderID());
-                        if(message.signal() == null){
-                            currentState.handleBadMessage();
-                            throw new IllegalArgumentException("Invalid data: " + " for message: " + message);
-                        }
-                        //values associated with servicing is the original message that was sent to the elevator
-                        String completedFloorReqID = message.reqID();
-                        elevatorRequestBuffer.remove(messageId);
-                        pendingFloorRequests.remove(completedFloorReqID);
-                        InetAddress floorAddr = InetAddress.getByName(message.senderAddr());
-                        MessageHelper.SendMessage(outSocket, message, floorAddr, floorSubSystemPort);
-                        idleElevators.put(String.valueOf(message.senderID()), message);
-                        break;
-                    default:
-                        currentState.handleBadMessage();
-                        throw new IllegalArgumentException("Invalid signal");
-                }
+    //ToDo: Does the FCS expect something in the data payload? currently it is null on response.
+    public boolean handleECSUpdate() throws InterruptedException, IOException {
+        boolean updated = false;
+
+        //Check the message buffer for updates. if theres none return false
+        if(!floorMessageBuffer.isBufferEmpty()) {
+            updated = true;
+            //If there is a message in the buffer construct an array of work assignemnts and submit them to allocate, then to the shared state
+            SerializableMessage[] floorReqs = floorMessageBuffer.get();
+//        ArrayList<WorkAssignment> newWorkAssignments = new ArrayList<>();
+            for (SerializableMessage floorReq : floorReqs) {
+                String reqId = floorReq.reqID();
+                int serviceFloor = floorReq.senderID();
+                int destinationFloor = Integer.parseInt(floorReq.data().requestFloor());
+                String assignmentTimeStamp = floorReq.data().time();
+                Direction direction = Objects.equals(floorReq.data().direction(), "UP") ? Direction.UP : Direction.DOWN;
+                String floorSenderAddr = floorReq.senderAddr();
+                int floorSenderPort = floorReq.senderPort();
+
+                WorkAssignment wa = new WorkAssignment(serviceFloor, destinationFloor, assignmentTimeStamp, direction, reqId, floorSenderAddr, floorSenderPort);
+
+//            newWorkAssignments.add(wa);
+                assignedWork.put(reqId, wa);
+                //Update the shared object with new work assignments
+                sharedState.addNewWorkAssignment(wa);
             }
         }
-        currentState.handleDoneServing();
-    }
 
+        //iterate through update, check for completed assignments, remove them from the assigned work buffer and respond
+        //to the floor system
+        for (int assignmentKey : sharedState.getWorkAssignments().keySet()) {
+            WorkAssignment wa = sharedState.getWorkAssignments().get(assignmentKey).peek();
+            assert wa != null;
+            if (wa.isPickupComplete() && wa.isDropoffComplete()) {
+                WorkAssignment completedAssignment = assignedWork.remove(wa.getFloorRequestId());
 
-    /**
-     * Retrieves messages from the shared buffer and parses them into the appropriate buffer.
-     * This is called after the thread is woken up from wait and messages are in the buffer.
-     * No params, no return, public for testing purposes
-     */
-    public void readBuffer(){
-        ElevatorLogger tLogger = new ElevatorLogger("ReaderThread");
-        byte[] buffer = new byte[1024];
-        DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
-        while (testStopBit) {
-            tLogger.info("Waiting for packet");
-            try {
-                inSocket.receive(packet);
-                try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(buffer, 0, packet.getLength()))) {
-                    SerializableMessage sm = (SerializableMessage) ois.readObject();
-                    tLogger.info("Received id: " + sm.senderID() + " Received addr: " + sm.senderAddr() + " Received port: " + sm.senderPort() + " Received payload: " + sm.data());
+                String floorAddr = completedAssignment.getSenderAddr();
+                //ToDo: POTENTIAL BUG! getbyname may not be correct method
+                InetAddress floorAddress = InetAddress.getByName(floorAddr);
+                int floorPort = completedAssignment.getSenderPort();
+                SerializableMessage message = new SerializableMessage(floorAddr, floorPort, Signal.DONE, MessageTypes.FLOOR, wa.getServiceFloor(), wa.getFloorRequestId(), wa.getFloorRequestId(), null);
+                MessageHelper.SendMessage(outSocket, message, floorAddress, floorSubSystemPort);
+            }else {
+                String floorAddr = wa.getSenderAddr();
+                //ToDo: POTENTIAL BUG! getbyname may not be correct method
+                InetAddress floorAddress = InetAddress.getByName(floorAddr);
+                int floorPort = wa.getSenderPort();
+                SerializableMessage message = new SerializableMessage(floorAddr, floorPort, Signal.WORKING, MessageTypes.FLOOR, wa.getServiceFloor(), wa.getFloorRequestId(), wa.getFloorRequestId(), null);
 
-                    switch (sm.type()) {
-                        case ELEVATOR -> elevatorRequestBuffer.put(sm.messageID(), sm);
-                        case FLOOR -> floorRequestBuffer.put(sm.messageID(), sm);
-                        default -> throw new IllegalArgumentException("Invalid message type");
-                    }
-
-                    currentState.handleDoneReadingRequest();
-
-                    if (currentState instanceof SchedulerScheduling state){
-                        SchedulerScheduling.SubState subState = state.getSubState();
-                        while (subState != SchedulerScheduling.SubState.READ_BUFF) {
-                            subState = state.getSubState();
-                            if (subState == SchedulerScheduling.SubState.SERVING_ELEVATORS)
-                                serveElevatorReqs();
-                            else if (subState == SchedulerScheduling.SubState.SERVING_FLOORS)
-                                serveFloorRequests();
-                        }
-                    }
-
-                } catch (Exception e) {
-                    System.err.println("Error during deserialization: " + e.getMessage());
-                    currentState.handleBadMessage();
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+                MessageHelper.SendMessage(outSocket, message, floorAddress, floorSubSystemPort);
             }
         }
+
+
+        return updated;
+
     }
-
-
-
-    /**
-     * Assigns idle elevators to floor requests and adds the request to pending floor requests.
-     * Pending floor requests are ones that are in the process of being serviced, they
-     * will have a counterpart "working elevator"
-     * <p>
-     * No params, no return, public for testing purposes
-     */
-    public void serveFloorRequests() throws IOException {
-        //go through idle elevators and assign them to floor requests, add the request to pending floor requests
-        String[] floorRequestKeys = floorRequestBuffer.keySet().toArray(new String[0]);
-        ArrayList<SerializableMessage> elevatorOutMessagePayload = new ArrayList<>();
-        for (String floorRequestId : floorRequestKeys) {
-            if (!idleElevators.isEmpty() && !floorRequestBuffer.isEmpty()) {
-
-                String idleElevatorId = idleElevators.keySet().iterator().next();
-                pendingFloorRequests.put(floorRequestId, floorRequestBuffer.get(floorRequestId));
-                SerializableMessage[] floorRequest = {pendingFloorRequests.get(floorRequestId)};
-
-                if (floorRequest[0] == null) {
-                    throw new IllegalArgumentException("Invalid floorRequest: " + null + " for floorRequestId: " + floorRequestId);
-                }
-
-                elevatorOutMessagePayload.addAll(Arrays.stream(floorRequest).toList());
-                floorRequestBuffer.remove(floorRequestId);
-                idleElevators.remove(idleElevatorId);
-            }
-        }
-        if (!elevatorOutMessagePayload.isEmpty()){
-            logger.info("Sending A Message to Elevators");
-            MessageHelper.SendMessages(outSocket, elevatorOutMessagePayload, InetAddress.getLocalHost(), elevatorSubSystemPort);
-        }
-        currentState.handleDoneServing();
-    }
-
 
 
 
@@ -249,20 +177,29 @@ public class Scheduler {
      * Starts the system
      */
     public void startSystem() {
-        currentState = SchedulerState.start(this);
-        readBuffer();
+        //ToDo: complete SchedulerV2, port changes over to scheduler class so this method can be called.
+//        currentState = SchedulerState.start(this);
+//        readBuffer();
+        floorMessageBuffer.listenAndFillBuffer();
+        //From what I've read, the RMI should be running in the background and manage the thread lifecycle.
+
         // Normal function of this class should not  reach this point. This is for testing only
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        inSocket.close();
-        outSocket.close();
+//        try {
+//            Thread.sleep(200);
+//        } catch (InterruptedException e) {
+//            throw new RuntimeException(e);
+//        }
+//        inSocket.close();
+//        outSocket.close();
     }
 
+
     public static void main(String[] args) throws IOException {
-        Scheduler s = new Scheduler(InetAddress.getLocalHost(),8080, 8081,8082);
+        AllocationStrategy allocationStrategy1 = new LoadBalancedStrategy();
+        SubSystemSharedState sharedState = new SubSystemSharedState();
+        Scheduler s = new Scheduler(InetAddress.getLocalHost(),8080, 8081,allocationStrategy1,sharedState);
+
         s.startSystem();
     }
 }
+

--- a/src/scheduler/SchedulerV2.java
+++ b/src/scheduler/SchedulerV2.java
@@ -1,33 +1,199 @@
+//package scheduler;
+//
+//import org.junit.runner.Runner;
+//import util.SubSystemSharedState;
+//
+//import java.rmi.AlreadyBoundException;
+//import java.rmi.RemoteException;
+//import java.rmi.registry.LocateRegistry;
+//import java.rmi.registry.Registry;
+//
+//public class SchedulerV2 implements Runnable {
+//    private SubSystemSharedState sharedState;
+//    Registry registry;
+//
+//
+//    public SchedulerV2(SubSystemSharedState sharedState) throws RemoteException, AlreadyBoundException {
+//        this.sharedState = sharedState;
+//        registry = LocateRegistry.getRegistry();
+//        registry.bind("SharedSubSystemState", sharedState);
+//    }
+//
+//
+//    public void schedule(){
+//        // Grab the state, then make assignents.
+//
+//    }
+//    public void run () {
+//        while (true) {
+//            // do something
+//
+//        }
+//    }
+//}
+
 package scheduler;
 
-import org.junit.runner.Runner;
-import util.SubSystemSharedState;
+import scheduler.strategies.AllocationStrategy;
+import util.*;
+import util.Messages.MessageTypes;
+import util.Messages.SerializableMessage;
+import util.Messages.Signal;
+import util.states.SchedulerState;
 
-import java.rmi.AlreadyBoundException;
-import java.rmi.RemoteException;
+import java.io.IOException;
+import java.net.*;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
-public class SchedulerV2 implements Runnable {
+
+/**
+ * The scheduler.Scheduler class is responsible for managing elevator and floor requests,
+ * assigning idle elevators to floor requests, and handling elevator status updates.
+ * It implements the Runnable interface to allow it to be executed in a separate thread.
+ * At hte moment it is at risk of circular wait, and needs to be refactored to use semaphores.
+ */
+public class SchedulerV2 {
+    private DatagramSocket inSocket;
+    private DatagramSocket outSocket;
+    private SchedulerState currentState;
     private SubSystemSharedState sharedState;
+
+    private
     Registry registry;
 
+    // Key is Message ID, Value is the message
+    //Requests are taken from the shared buffer and parsed into the appropriate buffer, these are requests that have yet
+    //to be serviced
 
-    public SchedulerV2(SubSystemSharedState sharedState) throws RemoteException, AlreadyBoundException {
-        this.sharedState = sharedState;
-        registry = LocateRegistry.getRegistry();
-        registry.bind("SharedSubSystemState", sharedState);
-    }
+    private static final ElevatorLogger logger = new ElevatorLogger("Scheduler");
+
+    private HashMap<String, WorkAssignment> assignedWork;
+
+    private int elevatorSubSystemPort;
+    private int floorSubSystemPort;
+    volatile boolean testStopBit;
+    private MessageBuffer floorMessageBuffer;
+    private AllocationStrategy allocationStrategy;
+
+    private ConcurrentLinkedDeque<WorkAssignment> pendingWorkAssignments;
 
 
-    public void schedule(){
-        // Grab the state, then make assignents.
-
-    }
-    public void run () {
-        while (true) {
-            // do something
-
+    /**
+     *  Creates a Scheduler
+     * @param schedulerAddr The Internet address of the scheduler
+     * @param schedulerPort The port that the scheduler listens to
+     * @param floorSubSystemPort The port that the floor system listens to
+     */
+    public SchedulerV2(InetAddress schedulerAddr, int schedulerPort, int floorSubSystemPort, AllocationStrategy allocationStrategy, SubSystemSharedState sharedState) {
+        try {
+            this.floorSubSystemPort = floorSubSystemPort;
+//            this.elevatorSubSystemPort = elevatorSubSystemPort;
+            inSocket = new DatagramSocket(schedulerPort, schedulerAddr);
+            InetSocketAddress inetSocketAddress = new InetSocketAddress(schedulerAddr, schedulerPort);
+            outSocket = new DatagramSocket();
+            floorMessageBuffer = new MessageBuffer("FloorMessageBuffer", inSocket, inetSocketAddress, schedulerPort);
+            testStopBit = true;
+            this.sharedState = sharedState;
+            registry = LocateRegistry.getRegistry();
+            registry.bind("SharedSubSystemState", sharedState);
+            assignedWork = new HashMap<>();
+            this.allocationStrategy = allocationStrategy;
+//            floorMessageBuffer.listenAndFillBuffer();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
+        currentState = null; // Started with startSystem()
+    }
+
+
+    //ToDo: Does the FCS expect something in the data payload? currently it is null on response.
+    public boolean handleECSUpdate() throws InterruptedException, IOException {
+
+        //Check the message buffer for updates. if theres none return false
+        if(floorMessageBuffer.isBufferEmpty()){
+            return false;
+        }
+        //If there is a message in the buffer construct an array of work assignemnts and submit them to allocate, then to the shared state
+        SerializableMessage[] floorReqs = floorMessageBuffer.get();
+        ArrayList<WorkAssignment> newWorkAssignments = new ArrayList<>();
+        for (SerializableMessage floorReq : floorReqs) {
+            String reqId = floorReq.reqID();
+            int serviceFloor = floorReq.senderID();
+            int destinationFloor = Integer.parseInt(floorReq.data().requestFloor());
+            String assignmentTimeStamp = floorReq.data().time();
+            Direction direction = Objects.equals(floorReq.data().direction(), "UP") ? Direction.UP : Direction.DOWN;
+            String floorSenderAddr = floorReq.senderAddr();
+            int floorSenderPort = floorReq.senderPort();
+
+            WorkAssignment wa = new WorkAssignment(serviceFloor, destinationFloor, assignmentTimeStamp, direction, reqId, floorSenderAddr, floorSenderPort);
+
+            newWorkAssignments.add(wa);
+            assignedWork.put(reqId, wa);
+            //Update the shared object with new work assignments
+            sharedState.addNewWorkAssignment(wa);
+        }
+
+        //iterate through update, check for completed assignments, remove them from the assigned work buffer and respond
+        //to the floor system
+        for (int assignmentKey : sharedState.getWorkAssignments().keySet()) {
+            WorkAssignment wa = sharedState.getWorkAssignments().get(assignmentKey).peek();
+            assert wa != null;
+            if (wa.isPickupComplete() && wa.isDropoffComplete()) {
+                WorkAssignment completedAssignment = assignedWork.remove(wa.getFloorRequestId());
+
+                String floorAddr = completedAssignment.getSenderAddr();
+                //ToDo: POTENTIAL BUG! getbyname may not be correct method
+                InetAddress floorAddress = InetAddress.getByName(floorAddr);
+                int floorPort = completedAssignment.getSenderPort();
+                SerializableMessage message = new SerializableMessage(floorAddr, floorPort, Signal.DONE, MessageTypes.FLOOR, wa.getServiceFloor(), wa.getFloorRequestId(), wa.getFloorRequestId(), null);
+                MessageHelper.SendMessage(outSocket, message, floorAddress, floorSubSystemPort);
+            }else {
+
+                String floorAddr = wa.getSenderAddr();
+                //ToDo: POTENTIAL BUG! getbyname may not be correct method
+                InetAddress floorAddress = InetAddress.getByName(floorAddr);
+                int floorPort = wa.getSenderPort();
+                SerializableMessage message = new SerializableMessage(floorAddr, floorPort, Signal.WORKING, MessageTypes.FLOOR, wa.getServiceFloor(), wa.getFloorRequestId(), wa.getFloorRequestId(), null);
+
+                MessageHelper.SendMessage(outSocket, message, floorAddress, floorSubSystemPort);
+            }
+        }
+
+
+        return true;
+
+    }
+
+
+
+    /**
+     * Starts the system
+     */
+    public void startSystem() {
+        //ToDo: complete SchedulerV2, port changes over to scheduler class so this method can be called.
+//        currentState = SchedulerState.start(this);
+//        readBuffer();
+        floorMessageBuffer.listenAndFillBuffer();
+        //From what I've read, the RMI should be running in the background and manage the thread lifecycle.
+
+        // Normal function of this class should not  reach this point. This is for testing only
+//        try {
+//            Thread.sleep(200);
+//        } catch (InterruptedException e) {
+//            throw new RuntimeException(e);
+//        }
+//        inSocket.close();
+//        outSocket.close();
+    }
+
+    public static void main(String[] args) throws IOException {
+        Scheduler s = new Scheduler(InetAddress.getLocalHost(),8080, 8081,8082);
+        s.startSystem();
     }
 }
+

--- a/src/scheduler/strategies/AllocationStrategy.java
+++ b/src/scheduler/strategies/AllocationStrategy.java
@@ -1,0 +1,14 @@
+package scheduler.strategies;
+
+import util.SubSystemSharedState;
+import util.WorkAssignment;
+
+import java.util.ArrayList;
+
+public abstract class AllocationStrategy {
+    protected SubSystemSharedState sharedState;
+    AllocationStrategy(SubSystemSharedState sharedState) {
+        this.sharedState = sharedState;
+    }
+    public abstract void allocate(ArrayList<WorkAssignment> workAssignments);
+}

--- a/src/scheduler/strategies/LoadBalancedStrategy.java
+++ b/src/scheduler/strategies/LoadBalancedStrategy.java
@@ -1,44 +1,53 @@
 package scheduler.strategies;
 
 import util.SubSystemSharedState;
+import util.WorkAssignment;
 
 import java.util.*;
 
-public class LoadBalancedStrategy {
-
-
-        public void allocate(SubSystemSharedState sharedState) {
-            HashMap<int, floorRequests = sharedState.getFloorRequests();
-            elevatorStates = sharedState.getElevatorStates();
-            int numRequestsPerElevator = floorRequests.size() / elevatorCars.size();
-            int numExtraRequests = floorRequests.size() % elevatorCars.size();
-
-            List<Integer> numStops = new ArrayList<>(Collections.nCopies(elevatorCars.size(), 0));
-
-            int requestIndex = 0;
-            for (int i = 0; i < elevatorCars.size(); i++) {
-                int numRequests = numRequestsPerElevator;
-                if (numExtraRequests > 0) {
-                    numRequests++;
-                    numExtraRequests--;
-                }
-
-                int minStopsIndex = 0;
-                for (int j = 1; j < elevatorCars.size(); j++) {
-                    if (numStops.get(j) < numStops.get(minStopsIndex)) {
-                        minStopsIndex = j;
-                    }
-                }
-
-                for (int j = 0; j < numRequests; j++) {
-                    FloorRequest request = floorRequests.get(requestIndex);
-                    elevatorCars.get(minStopsIndex).assignFloorRequest(request.floor, request.direction);
-                    numStops.set(minStopsIndex, numStops.get(minStopsIndex) + 1);
-                    requestIndex++;
-                }
-            }
-
-            floorRequests.clear();
+public class LoadBalancedStrategy extends AllocationStrategy{
+        LoadBalancedStrategy(SubSystemSharedState sharedState) {
+            super(sharedState);
         }
+
+//        public void allocate(SubSystemSharedState sharedState) {
+//            HashMap<int, floorRequests = sharedState.getFloorRequests();
+//            elevatorStates = sharedState.getElevatorStates();
+//            int numRequestsPerElevator = floorRequests.size() / elevatorCars.size();
+//            int numExtraRequests = floorRequests.size() % elevatorCars.size();
+//
+//            List<Integer> numStops = new ArrayList<>(Collections.nCopies(elevatorCars.size(), 0));
+//
+//            int requestIndex = 0;
+//            for (int i = 0; i < elevatorCars.size(); i++) {
+//                int numRequests = numRequestsPerElevator;
+//                if (numExtraRequests > 0) {
+//                    numRequests++;
+//                    numExtraRequests--;
+//                }
+//
+//                int minStopsIndex = 0;
+//                for (int j = 1; j < elevatorCars.size(); j++) {
+//                    if (numStops.get(j) < numStops.get(minStopsIndex)) {
+//                        minStopsIndex = j;
+//                    }
+//                }
+//
+//                for (int j = 0; j < numRequests; j++) {
+//                    FloorRequest request = floorRequests.get(requestIndex);
+//                    elevatorCars.get(minStopsIndex).assignFloorRequest(request.floor, request.direction);
+//                    numStops.set(minStopsIndex, numStops.get(minStopsIndex) + 1);
+//                    requestIndex++;
+//                }
+//            }
+//
+//            floorRequests.clear();
+//        }
+//
+    @Override
+    public void allocate(ArrayList<WorkAssignment> workAssignments) {
+
+
     }
 }
+

--- a/src/scheduler/strategies/LoadBalancedStrategy.java
+++ b/src/scheduler/strategies/LoadBalancedStrategy.java
@@ -1,12 +1,11 @@
 package scheduler.strategies;
 
-import util.SubSystemSharedState;
 import util.WorkAssignment;
 
 import java.util.*;
 
 public class LoadBalancedStrategy extends AllocationStrategy{
-        LoadBalancedStrategy(SubSystemSharedState sharedState) {
+        public LoadBalancedStrategy() {
             super(sharedState);
         }
 

--- a/src/util/ElevatorStateUpdate.java
+++ b/src/util/ElevatorStateUpdate.java
@@ -1,0 +1,61 @@
+package util;
+
+import util.Messages.Signal;
+
+import java.util.ArrayList;
+
+public class ElevatorStateUpdate {
+    private int elevatorId;
+    private int curFloor;
+    private int destinationFloor;
+    private Direction direction;
+    private ArrayList<WorkAssignment> workAssignments;
+    private Signal stateSignal;
+
+    public ElevatorStateUpdate(int elevatorId, int floor, Direction direction, ArrayList<WorkAssignment> workAssignments) {
+        this.elevatorId = elevatorId;
+        this.curFloor = floor;
+        this.direction = direction;
+        this.workAssignments = workAssignments;
+    }
+
+    public int getElevatorId() {
+        return elevatorId;
+    }
+
+    public int getFloor() {
+        return curFloor;
+    }
+
+    public ArrayList<WorkAssignment> getWorkAssignments() {
+        return workAssignments;
+    }
+
+    public Signal getStateSignal() {
+        return stateSignal;
+    }
+
+    public void setStateSignal(Signal signal) {
+        stateSignal = signal;
+    }
+
+    public void setDestinationFloor(int destinationFloor) {
+        this.destinationFloor = destinationFloor;
+    }
+
+    public int getDestinationFloor() {
+        return destinationFloor;
+    }
+
+    public void setDirection(Direction direction) {
+        this.direction = direction;
+    }
+
+    public void setWorkAssignments(ArrayList<WorkAssignment> workAssignments) {
+        this.workAssignments = workAssignments;
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+}

--- a/src/util/SubSystemSharedState.java
+++ b/src/util/SubSystemSharedState.java
@@ -4,20 +4,37 @@ import scheduler.Scheduler;
 import scheduler.SchedulerV2;
 import util.states.ElevatorState;
 
+import java.io.IOException;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class SubSystemSharedState extends UnicastRemoteObject {
 
-    private HashMap <Integer, ConcurrentLinkedDeque<ElevatorState>> elevatorStates;
+    private HashMap <Integer, ElevatorStateUpdate> elevatorStates;
 
-    private HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> floorRequests;
 
-    private HashMap<Integer, ConcurrentLinkedDeque<int>> workAssignments;
+    // Placeholder this needsd to change
+    private HashMap<Integer, ConcurrentLinkedDeque<WorkAssignment>> workAssignments;
+
+    private ArrayList<WorkAssignment> newWorkAssignmentBuffer;
     SchedulerV2 scheduler;
+
+
+
+
+
+
+
+
+    // If this method returns true then there has been updated floor requests. The ECS should reconsider.
+    public boolean ecsUpdate(HashMap<Integer, ElevatorStateUpdate> stateUpdate) throws InterruptedException, IOException {
+        elevatorStates = stateUpdate;
+        return scheduler.handleECSUpdate();
+    }
 
     public SubSystemSharedState(SchedulerV2 sched) throws RemoteException {
         super();
@@ -25,77 +42,100 @@ public class SubSystemSharedState extends UnicastRemoteObject {
         scheduler = sched;
     }
 
-
-
-    //interger return value is a place holder.
-    public ConcurrentLinkedDeque<int> getWorkAssignment(int elevatorId) {
-        return workAssignments.get(elevatorId);
+    public void addWorkAssignmentBuffer(WorkAssignment workAssignment) {
+        newWorkAssignmentBuffer.add(workAssignment);
     }
 
-    public void addWorkAssignment(int elevatorId, int floor) {
-        workAssignments.get(elevatorId).add(floor);
+    public ArrayList<WorkAssignment> flushNewWorkAssignmentBuffer() {
+        // Will clearing the buffer also clear temp?
+        ArrayList<WorkAssignment> temp = newWorkAssignmentBuffer;
+        newWorkAssignmentBuffer.clear();
+        return temp;
     }
 
-    public void setWorkAssignments(HashMap<Integer, ConcurrentLinkedDeque<int>> workAssignments) {
-        this.workAssignments = workAssignments;
+    public void setNewWorkAssignmentsBuffer(ArrayList<WorkAssignment> workAssignments) {
+        newWorkAssignmentBuffer = workAssignments;
+    }
+
+    public ArrayList<WorkAssignment> getWorkAssignmentsBuffer() {
+        return newWorkAssignmentBuffer;
     }
 
 
-
-
-    public void registerElevator(int elevatorId) {
-        elevatorStates.put(elevatorId, new ConcurrentLinkedDeque<>());
-    }
-    public void registerFloor(int floor) {
-        floorRequests.put(floor, new ConcurrentLinkedDeque<>());
-    }
-    public void setFloors(HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> floorRequests) {
-        this.floorRequests = floorRequests;
-    }
-    public void setElevators (HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> elevatorStates) {
-        this.elevatorStates = elevatorStates;
-    }
-
-    public HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> getFloorRequests() {
-        return floorRequests;
-    }
-
-    public void addFloorRequest(int floor, ElevatorState state) {
-        floorRequests.get(floor).add(state);
-    }
-    public void setFloorRequests(HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> floorRequests) {
-        this.floorRequests = floorRequests;
-    }
-
-    public void addState(int elevatorId, ElevatorState state) {
-        elevatorStates.get(elevatorId).add(state);
-    }
-
-    public ElevatorState peekState(int elevatorId) {
-        return elevatorStates.get(elevatorId).peek();
-    }
-
-    public void setState(HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> elevatorStates) {
-        this.elevatorStates = elevatorStates;
-    }
-
-    public HashMap<Integer, ConcurrentLinkedDeque<ElevatorState>> getElevatorStates() {
+    public HashMap<Integer, ElevatorStateUpdate> getElevatorStates() {
         return elevatorStates;
     }
 
-    public ElevatorState popElevatorState(int elevatorId) {
-        ElevatorState state = peekState(elevatorId);
-        elevatorStates.get(elevatorId).pop();
-        return state;
+    //interger return value is a place holder.
+
+
+
+
+    public void setElevatorStates(HashMap<Integer, ElevatorStateUpdate> elevatorStates) {
+        this.elevatorStates = elevatorStates;
     }
 
+    public void setWorkAssignments(HashMap<Integer, ConcurrentLinkedDeque<WorkAssignment>> workAssignments) {
+        this.workAssignments = workAssignments;
+    }
 
+    public HashMap<Integer, ConcurrentLinkedDeque<WorkAssignment>> getWorkAssignments() {
+        return workAssignments;
+    }
 
+    public void addElevatorState(int elevatorId, ElevatorStateUpdate elevatorState) {
+        elevatorStates.put(elevatorId, elevatorState);
+    }
 
+    public void removeElevatorState(int elevatorId) {
+        elevatorStates.remove(elevatorId);
+    }
 
+    public void addNewWorkAssignment(WorkAssignment workAssignment) {
+        newWorkAssignmentBuffer.add(workAssignment);
+    }
 
+    public void addWorkAssignment(int elevatorId, WorkAssignment workAssignment) {
+        workAssignments.get(elevatorId).add(workAssignment);
+    }
 
+    public void removeWorkAssignment(int elevatorId, WorkAssignment workAssignment) {
+        workAssignments.get(elevatorId).remove(workAssignment);
+    }
 
+    public void setWorkAssignmentQueue(int elevatorId, ConcurrentLinkedDeque<WorkAssignment> workAssignments) {
+        this.workAssignments.put(elevatorId, workAssignments);
+    }
 
+    public ConcurrentLinkedDeque<WorkAssignment> getWorkAssignmentQueue(int elevatorId) {
+        return workAssignments.get(elevatorId);
+    }
+
+    public void clearWorkAssignmentQueue(int elevatorId) {
+        workAssignments.get(elevatorId).clear();
+    }
+
+    public void setAllWorkAssignments(HashMap<Integer, ConcurrentLinkedDeque<WorkAssignment>> workAssignments) {
+        this.workAssignments = workAssignments;
+    }
+
+    public void clearAllWorkAssignments() {
+        for (int elevatorId : workAssignments.keySet()) {
+            workAssignments.get(elevatorId).clear();
+        }
+    }
+
+    public void clearAllElevatorStates() {
+        elevatorStates.clear();
+    }
+
+    public void clearAll() {
+        clearAllWorkAssignments();
+        clearAllElevatorStates();
+    }
+
+    public HashMap<Integer, ConcurrentLinkedDeque<WorkAssignment>> getAllWorkAssignments() {
+        return workAssignments;
+    }
 
 }

--- a/src/util/SubSystemSharedState.java
+++ b/src/util/SubSystemSharedState.java
@@ -1,15 +1,12 @@
 package util;
 
-import scheduler.Scheduler;
 import scheduler.SchedulerV2;
-import util.states.ElevatorState;
 
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class SubSystemSharedState extends UnicastRemoteObject {
@@ -36,15 +33,15 @@ public class SubSystemSharedState extends UnicastRemoteObject {
         return scheduler.handleECSUpdate();
     }
 
-    public SubSystemSharedState(SchedulerV2 sched) throws RemoteException {
+    public void setScheduler(SchedulerV2 scheduler) {
+        this.scheduler = scheduler;
+    }
+    public SubSystemSharedState() throws RemoteException {
         super();
         elevatorStates = new HashMap<>();
-        scheduler = sched;
     }
 
-    public void addWorkAssignmentBuffer(WorkAssignment workAssignment) {
-        newWorkAssignmentBuffer.add(workAssignment);
-    }
+
 
     public ArrayList<WorkAssignment> flushNewWorkAssignmentBuffer() {
         // Will clearing the buffer also clear temp?
@@ -57,7 +54,7 @@ public class SubSystemSharedState extends UnicastRemoteObject {
         newWorkAssignmentBuffer = workAssignments;
     }
 
-    public ArrayList<WorkAssignment> getWorkAssignmentsBuffer() {
+    public ArrayList<WorkAssignment> getNewWorkAssignmentsBuffer() {
         return newWorkAssignmentBuffer;
     }
 

--- a/src/util/SubSystemSharedState.java
+++ b/src/util/SubSystemSharedState.java
@@ -1,5 +1,6 @@
 package util;
 
+import scheduler.Scheduler;
 import scheduler.SchedulerV2;
 
 import java.io.IOException;
@@ -18,7 +19,7 @@ public class SubSystemSharedState extends UnicastRemoteObject {
     private HashMap<Integer, ConcurrentLinkedDeque<WorkAssignment>> workAssignments;
 
     private ArrayList<WorkAssignment> newWorkAssignmentBuffer;
-    SchedulerV2 scheduler;
+    Scheduler scheduler;
 
 
 
@@ -33,7 +34,7 @@ public class SubSystemSharedState extends UnicastRemoteObject {
         return scheduler.handleECSUpdate();
     }
 
-    public void setScheduler(SchedulerV2 scheduler) {
+    public void setScheduler(Scheduler scheduler) {
         this.scheduler = scheduler;
     }
     public SubSystemSharedState() throws RemoteException {

--- a/src/util/WorkAssignment.java
+++ b/src/util/WorkAssignment.java
@@ -1,5 +1,7 @@
 package util;
 
+import java.net.InetAddress;
+
 public class WorkAssignment {
     private int serviceFloor;
     private int destinationFloor;
@@ -15,21 +17,34 @@ public class WorkAssignment {
 
 
     private Direction direction;
+    private String senderAddr;
+    private int senderPort;
 
 
 
 
-    public WorkAssignment(int serviceFloor, int destinationFloor, String assignmentTimeStamp, Direction direction, String floorRequestId) {
+    public WorkAssignment(int serviceFloor, int destinationFloor, String assignmentTimeStamp, Direction direction, String floorRequestId, String senderAddr, int senderPort) {
         this.serviceFloor = serviceFloor;
         this.destinationFloor = destinationFloor;
         this.assignmentTimeStamp = assignmentTimeStamp;
         this.direction = direction;
         this.assignmentId = assignmentTimeStamp + serviceFloor + destinationFloor;
         this.floorRequestId = floorRequestId;
+        this.senderAddr = senderAddr;
+        this.senderPort = senderPort;
     }
 
     public int getServiceFloor() {
         return serviceFloor;
+    }
+    public String getSenderAddr() {
+        return senderAddr;
+    }
+    public int getSenderPort() {
+        return senderPort;
+    }
+    public String getFloorRequestId() {
+        return floorRequestId;
     }
 
     public int getDestinationFloor() {


### PR DESCRIPTION
I've yet to test this as it requires refactors on the ECS side, but this *should* work. 

The ECS is responsible for calling ecsUpdate and assumes the ECS is still responsible for the logic of elevator allocation. This will need to change but lets get it working first. 
